### PR TITLE
Flask-WTF 0.6 changes

### DIFF
--- a/flask_dashed/templates/flask_dashed/form.html
+++ b/flask_dashed/templates/flask_dashed/form.html
@@ -1,7 +1,7 @@
 {% macro render_form(form, legend=None, child=False) %}
     {% if not child %}
-        {{ form.csrf }}
-        {% if form.csrf.errors %}
+        {{ form.csrf_token }}
+        {% if form.csrf_token.errors %}
             <ul class="errors">
                 {% for error in form.csrf.errors %}<li>{{ error }}{% endfor %}
             </ul>


### PR DESCRIPTION
Flask-WTF 0.6 changes from csrf to csrf-token.  Not sure if you want to force a version number as well on your setup.py for Flask-WTF, so I didn't change anything there.
